### PR TITLE
added #partial to wsa_err_incomplete

### DIFF
--- a/nbio/nbio_internal_windows.odin
+++ b/nbio/nbio_internal_windows.odin
@@ -514,7 +514,7 @@ LPFN_ACCEPTEX :: #type proc "stdcall" (
 ) -> win.BOOL
 
 wsa_err_incomplete :: proc(err: win.c_int) -> bool {
-	switch win.System_Error(err) {
+	#partial switch win.System_Error(err) {
 	case .WSAEWOULDBLOCK, .IO_PENDING, .IO_INCOMPLETE, .WSAEALREADY:
 		return true
 	case:


### PR DESCRIPTION
## Describe your changes
Added `#partial` to `nbio_internal_windows.wsa_err_incomplete()` as the previous commit had moved to using a switch statement, but the cases were not exhausted. Resulting in compilation failure on windows. 

## Issue ticket number and link
- Issue: https://github.com/laytan/odin-http/issues/42

## Testing
``` go
Some_Enum :: enum {
    None,
    Yadda,
    Elo,
}

...
some_enum := Some_Enum.None

// Fails to compile
switch some_enum {
case .Yadda, .Elo:
    fmt.println("Yadda || Elo")
case:
    fmt.println("None")
}

// Defaults to the default case and prints "None"
#partial switch some_enum {
case .Yadda, .Elo:
    fmt.println("Yadda || Elo")
case:
    fmt.println("None")
}
```