### PR TITLE
Fix example/client not compiling.

### DIFF
--- a/nbio/nbio_internal_darwin.odin
+++ b/nbio/nbio_internal_darwin.odin
@@ -162,7 +162,7 @@ flush :: proc(io: ^IO) -> os.Errno {
 
 flush_io :: proc(io: ^IO, events: []kqueue.KEvent) -> int {
 	events := events
-	events_loop: for event, i in &events {
+	events_loop: for &event, i in events {
 		if len(io.io_pending) <= i do return i
 		completion := io.io_pending[i]
 


### PR DESCRIPTION
Compiling `example/client` produces the following output on macOS:

```
cd "/Users/yay/projects/odin-http/examples/client/" && rodina
/Users/yay/projects/odin-http $ cd "/Users/yay/projects/odin-http/examples/client/" && rodina
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:171:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(op.sock) 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:172:4: Error: Cannot assign to 'event.filter' 
        event.filter = kqueue.EVFILT_READ 
        ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:174:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(op.socket) 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:175:4: Error: Cannot assign to 'event.filter' 
        event.filter = kqueue.EVFILT_WRITE 
        ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:177:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(op.fd) 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:178:4: Error: Cannot assign to 'event.filter' 
        event.filter = kqueue.EVFILT_READ 
        ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:180:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(op.fd) 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:181:4: Error: Cannot assign to 'event.filter' 
        event.filter = kqueue.EVFILT_WRITE 
        ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:183:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(os.Socket(net.any_socket_to_socket(op.sock ... 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:184:4: Error: Cannot assign to 'event.filter' 
        event.filter = kqueue.EVFILT_READ 
        ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:186:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(os.Socket(net.any_socket_to_socket(op.sock ... 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:187:4: Error: Cannot assign to 'event.filter' 
        event.filter = kqueue.EVFILT_WRITE 
        ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:189:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(op.fd) 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:191:17: Error: Cannot assign to 'event.filter' 
        case .Read:  event.filter = kqueue.EVFILT_READ 
                     ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:192:17: Error: Cannot assign to 'event.filter' 
        case .Write: event.filter = kqueue.EVFILT_WRITE 
                     ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:196:4: Error: Cannot assign to 'event.flags' 
        event.flags = kqueue.EV_ADD | kqueue.EV_ENABLE 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:198:5: Error: Cannot assign to 'event.flags' 
        event.flags |= kqueue.EV_ONESHOT 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:201:4: Error: Cannot assign to 'event.udata' 
        event.udata = completion 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:205:4: Error: Cannot assign to 'event.ident' 
        event.ident = uintptr(op.fd) 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:207:17: Error: Cannot assign to 'event.filter' 
        case .Read:  event.filter = kqueue.EVFILT_READ 
                     ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:208:17: Error: Cannot assign to 'event.filter' 
        case .Write: event.filter = kqueue.EVFILT_WRITE 
                     ^~~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:212:4: Error: Cannot assign to 'event.flags' 
        event.flags = kqueue.EV_DELETE | kqueue.EV_DISABLE | kqueue.EV_O ... 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:214:4: Error: Cannot assign to 'event.udata' 
        event.udata = completion 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:221:3: Error: Cannot assign to 'event.flags' 
        event.flags = kqueue.EV_ADD | kqueue.EV_ENABLE | kqueue.EV_ONESH ... 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/nbio/nbio_internal_darwin.odin:222:3: Error: Cannot assign to 'event.udata' 
        event.udata = completion 
        ^~~~~~~~~~^ 
        events_loop: for event, i in &events { 
                         ^~~~^ 
                        'event' is immutable, declare it as '&event' to make it mutable 
/Users/yay/projects/odin-http/examples/client $ 
```