### PR TITLE
[win nbio] Fix issues with CreateIoCompletionPort

### DIFF
--- a/nbio/nbio_internal_windows.odin
+++ b/nbio/nbio_internal_windows.odin
@@ -140,7 +140,7 @@ prepare_socket :: proc(io: ^IO, socket: net.Any_Socket) -> net.Network_Error {
 
 	handle := win.HANDLE(uintptr(net.any_socket_to_socket(socket)))
 
-	handle_iocp := win.CreateIoCompletionPort(handle, io.iocp, nil, 0)
+	handle_iocp := win.CreateIoCompletionPort(handle, io.iocp, 0, 0)
 	assert(handle_iocp == io.iocp)
 
 	mode: byte

--- a/nbio/nbio_windows.odin
+++ b/nbio/nbio_windows.odin
@@ -21,7 +21,7 @@ _init :: proc(io: ^IO, allocator := context.allocator) -> (err: os.Errno) {
 		assert(win.WSACleanup() == win.NO_ERROR)
 	}
 
-	io.iocp = win.CreateIoCompletionPort(win.INVALID_HANDLE_VALUE, nil, nil, 0)
+	io.iocp = win.CreateIoCompletionPort(win.INVALID_HANDLE_VALUE, nil, 0, 0)
 	if io.iocp == nil {
 		err = os.Errno(win.GetLastError())
 		return
@@ -174,7 +174,7 @@ _open :: proc(io: ^IO, path: string, mode, perm: int) -> (os.Handle, os.Errno) {
 
 	// Everything past here is custom/not from `os.open`.
 
-	handle_iocp := win.CreateIoCompletionPort(win.HANDLE(handle), io.iocp, nil, 0)
+	handle_iocp := win.CreateIoCompletionPort(win.HANDLE(handle), io.iocp, 0, 0)
 	assert(handle_iocp == io.iocp)
 
 	cmode: byte


### PR DESCRIPTION
Fix issue changes by this commit https://github.com/odin-lang/Odin/commit/1617060f46d2467dff185c6c7c43ff8d7ed6e36e `CompletionKey` is now a uint instead of a uintptr.