### PR TITLE
Allow running handler serverless for testing

### DIFF
--- a/response.odin
+++ b/response.odin
@@ -241,7 +241,7 @@ _response_write_heading :: proc(r: ^Response, content_length: int) {
 	ws(b, "\r\n")
 
 	// Per RFC 9910 6.6.1 a Date header must be added in 2xx, 3xx, 4xx responses.
-	if r.status >= .OK && r.status <= .Internal_Server_Error && !headers_has_unsafe(r.headers, "date") {
+	if td.state != .Testing && r.status >= .OK && r.status <= .Internal_Server_Error && !headers_has_unsafe(r.headers, "date") {
 		ws(b, "date: ")
 		ws(b, server_date(conn.server))
 		ws(b, "\r\n")

--- a/responses.odin
+++ b/responses.odin
@@ -42,7 +42,9 @@ If any other error occurs, a 500 is sent and the error is logged.
 */
 respond_file :: proc(r: ^Response, path: string, content_type: Maybe(Mime_Type) = nil, loc := #caller_location) {
 	// PERF: we are still putting the content into the body buffer, we could stream it.
-
+	if td.state == .Testing {
+		return
+	}
 	assert_has_td(loc)
 	assert(!r.sent, "response has already been sent", loc)
 
@@ -168,6 +170,9 @@ respond_json :: proc(r: ^Response, v: any, status: Status = .OK, opt: json.Marsh
 Prefer the procedure group `respond`.
 */
 respond_with_none :: proc(r: ^Response, loc := #caller_location) {
+	if td.state == .Testing {
+		return
+	}
 	assert_has_td(loc)
 
 	conn := r._conn

--- a/server.odin
+++ b/server.odin
@@ -78,6 +78,7 @@ Server_State :: enum {
 	Closing,
 	Cleaning,
 	Closed,
+	Testing,
 }
 
 Server :: struct {


### PR DESCRIPTION
This commit allow for serverless testing, this is a code snippet on how to use it:
```
import "core:testing"
import http "."

@(test)
test_handler :: proc(t: ^testing.T) {
	http.td.state=.Testing

	req : http.Request
	res : http.Response

	handler(&req, &res)

	testing.expect( t, res.status==.OK )
}
```

The testing report leaks but I'm not sure if those are from this pull request
```
        +++ leak       448B @ 0x7FA2B31210C0 [headers.odin:37:headers_set_unsafe()]
        +++ leak       113B @ 0x7FA2B3121288 [response.odin:227:_response_write_heading()]

```