### PR TITLE
Fix compilation error after the core:net update

### DIFF
--- a/server.odin
+++ b/server.odin
@@ -415,7 +415,7 @@ on_accept :: proc(server: rawptr, sock: net.TCP_Socket, source: net.Endpoint, er
 		#partial switch e in err {
 		case net.Accept_Error:
 			#partial switch e {
-			case .No_Socket_Descriptors_Available_For_Client_Socket:
+			case .Insufficient_Resources:
 				log.error("Connection limit reached, trying again in a bit")
 				nbio.timeout(&td.io, time.Second, server, proc(server: rawptr) {
 					server := cast(^Server)server


### PR DESCRIPTION
After PR [#5007](https://github.com/odin-lang/Odin/pull/5007) for Odin, the `odin-http` library fails to compile. This PR fixes the compilation issue by updating the error handling code.