### PR TITLE
Allow compiling with `-disallow-do`, `-vet-tabs`, etc.

### DIFF
--- a/allocator.odin
+++ b/allocator.odin
@@ -150,7 +150,7 @@ allocator_alloc_zerod :: proc(a: ^Allocator, size: int, alignment: int, loc := #
 }
 
 allocator_alloc_non_zerod :: proc(a: ^Allocator, size: int, alignment: int, loc := #caller_location) -> (bytes: []byte, err: mem.Allocator_Error) {
-	if size == 0 do return
+	if size == 0 { return }
 
 	block := a.curr
 	data := ([^]byte)(&block.data)

--- a/body.odin
+++ b/body.odin
@@ -60,7 +60,7 @@ body_url_encoded :: proc(plain: Body, allocator := context.temp_allocator) -> (r
 
 	count := 1
 	for b in plain {
-		if b == '&' do count += 1
+		count += 1 if b == '&' else 0
 	}
 
 	queries := make(map[string]string, count, allocator)

--- a/cookie.odin
+++ b/cookie.odin
@@ -93,11 +93,12 @@ cookie_string :: proc(c: Cookie, allocator := context.allocator) -> string {
 cookie_parse :: proc(value: string, allocator := context.allocator) -> (cookie: Cookie, ok: bool) {
 	value := value
 
-	eq := strings.index_byte(value, '=')
-	if eq < 1 do return
-
-	cookie.name = value[:eq]
-	value = value[eq + 1:]
+	if eq := strings.index_byte(value, '='); eq < 1 {
+		return
+	} else {
+		cookie.name = value[:eq]
+		value = value[eq + 1:]
+	}
 
 	semi := strings.index_byte(value, ';')
 	switch semi {
@@ -372,7 +373,9 @@ request_cookie_get :: proc(r: ^Request, key: string) -> (value: string, ok: bool
 	cookies := headers_get_unsafe(r.headers, "cookie") or_return
 
 	for k, v in request_cookies_iter(&cookies) {
-		if key == k do return v, true
+		if key == k {
+			return v, true
+		}
 	}
 
 	return
@@ -389,7 +392,7 @@ request_cookies :: proc(r: ^Request, allocator := context.temp_allocator) -> (re
 	cookies := headers_get_unsafe(r.headers, "cookie") or_else ""
 	for k, v in request_cookies_iter(&cookies) {
 		// Don't overwrite, the iterator goes from right to left and we want the last.
-		if k in res do continue
+		if k in res { continue }
 
 		res[k] = v
 	}

--- a/http.odin
+++ b/http.odin
@@ -34,22 +34,27 @@ Requestline :: struct {
 requestline_parse :: proc(s: string, allocator := context.temp_allocator) -> (line: Requestline, err: Requestline_Error) {
 	s := s
 
-	next_space := strings.index_byte(s, ' ')
-	if next_space == -1 do return line, .Not_Enough_Fields
+	next_space: int
+	if next_space = strings.index_byte(s, ' '); next_space == -1 {
+		return line, .Not_Enough_Fields
+	}
 
 	ok: bool
-	line.method, ok = method_parse(s[:next_space])
-	if !ok do return line, .Method_Not_Implemented
+	if line.method, ok = method_parse(s[:next_space]); !ok {
+		return line, .Method_Not_Implemented
+	}
 	s = s[next_space + 1:]
 
-	next_space = strings.index_byte(s, ' ')
-	if next_space == -1 do return line, .Not_Enough_Fields
+	if next_space = strings.index_byte(s, ' '); next_space == -1 {
+		return line, .Not_Enough_Fields
+	}
 
 	line.target = strings.clone(s[:next_space], allocator)
 	s = s[len(line.target.(string)) + 1:]
 
-	line.version, ok = version_parse(s)
-	if !ok do return line, .Invalid_Version_Format
+	if line.version, ok = version_parse(s); !ok {
+		return line, .Invalid_Version_Format
+	}
 
 	return
 }
@@ -131,8 +136,7 @@ Method :: enum {
 _method_strings := [?]string{"GET", "POST", "DELETE", "PATCH", "PUT", "HEAD", "CONNECT", "OPTIONS", "TRACE"}
 
 method_string :: proc(m: Method) -> string #no_bounds_check {
-	if m < .Get || m > .Trace do return ""
-	return _method_strings[m]
+	return "" if m < .Get || m > .Trace else _method_strings[m]
 }
 
 method_parse :: proc(m: string) -> (method: Method, ok: bool) #no_bounds_check {
@@ -273,7 +277,7 @@ date_string :: proc(t: time.Time, allocator := context.allocator) -> string {
 }
 
 date_parse :: proc(value: string) -> (t: time.Time, ok: bool) #no_bounds_check {
-	if len(value) != DATE_LENGTH do return
+	if len(value) != DATE_LENGTH { return }
 
 	// Remove 'Fri, '
 	value := value
@@ -294,7 +298,7 @@ date_parse :: proc(value: string) -> (t: time.Time, ok: bool) #no_bounds_check {
 		}
 	}
 	month_index += 1
-	if month_index <= 0 do return
+	if month_index <= 0 { return }
 
 	year := strconv.parse_i64_of_base(value[:4], 10) or_return
 	value = value[4:]
@@ -309,7 +313,7 @@ date_parse :: proc(value: string) -> (t: time.Time, ok: bool) #no_bounds_check {
 	value = value[3:]
 
 	// Should have only 'GMT' left now.
-	if value != "GMT" do return
+	if value != "GMT" { return }
 
 	t = time.datetime_to_time(int(year), int(month_index), int(day), int(hour), int(minute), int(seconds)) or_return
 	ok = true

--- a/nbio/_io_uring/os.odin
+++ b/nbio/_io_uring/os.odin
@@ -96,7 +96,7 @@ io_uring_init :: proc(ring: ^IO_Uring, entries: u32, params: ^io_uring_params) -
 	assert((params.flags & IORING_SETUP_SQE128) == 0)
 
 	sq, ok := submission_queue_make(fd, params)
-	if !ok do return .System_Resources
+	if !ok { return .System_Resources }
 
 	ring.fd = fd
 	ring.sq = sq
@@ -241,7 +241,7 @@ flush_sq :: proc(ring: ^IO_Uring) -> (n_pending: u32) {
 // Matches the implementation of sq_ring_needs_enter() in liburing.
 sq_ring_needs_enter :: proc(ring: ^IO_Uring, flags: ^u32) -> bool {
 	assert(flags^ == 0)
-	if ring.flags & IORING_SETUP_SQPOLL == 0 do return true
+	if ring.flags & IORING_SETUP_SQPOLL == 0 { return true }
 	if sync.atomic_load_explicit(ring.sq.flags, .Relaxed) & IORING_SQ_NEED_WAKEUP != 0 {
 		flags^ |= IORING_ENTER_SQ_WAKEUP
 		return true
@@ -267,7 +267,7 @@ cq_ready :: proc(ring: ^IO_Uring) -> (n_ready: u32) {
 // Provides all the wait/peek methods found in liburing, but with batching and a single method.
 copy_cqes :: proc(ring: ^IO_Uring, cqes: []io_uring_cqe, wait_nr: u32) -> (n_copied: u32, err: IO_Uring_Error) {
 	n_copied = copy_cqes_ready(ring, cqes)
-	if n_copied > 0 do return
+	if n_copied > 0 { return }
 	if wait_nr > 0 || cq_ring_needs_flush(ring) {
 		_ = enter(ring, 0, wait_nr, IORING_ENTER_GETEVENTS) or_return
 		n_copied = copy_cqes_ready(ring, cqes)
@@ -307,7 +307,7 @@ cqe_seen :: proc(ring: ^IO_Uring) {
 // For advanced use cases only that implement custom completion queue methods.
 // Matches the implementation of cq_advance() in liburing.
 cq_advance :: proc(ring: ^IO_Uring, count: u32) {
-	if count == 0 do return
+	if count == 0 { return }
 	sync.atomic_store_explicit(ring.cq.head, ring.cq.head^ + count, .Release)
 }
 
@@ -669,8 +669,8 @@ submission_queue_make :: proc(fd: os.Handle, params: ^io_uring_params) -> (sq: S
 		int(fd),
 		IORING_OFF_SQ_RING,
 	)
-	if mmap_result < 0 do return
-	defer if !ok do unix.sys_munmap(rawptr(uintptr(mmap_result)), uint(size))
+	if mmap_result < 0 { return }
+	defer if !ok { unix.sys_munmap(rawptr(uintptr(mmap_result)), uint(size)) }
 
 	mmap := transmute([^]u8)uintptr(mmap_result)
 
@@ -684,7 +684,7 @@ submission_queue_make :: proc(fd: os.Handle, params: ^io_uring_params) -> (sq: S
 		int(fd),
 		IORING_OFF_SQES,
 	)
-	if mmap_sqes_result < 0 do return
+	if mmap_sqes_result < 0 { return }
 
 	array := cast([^]u32)&mmap[params.sq_off.array]
 	sqes := cast([^]io_uring_sqe)uintptr(mmap_sqes_result)

--- a/nbio/nbio_darwin.odin
+++ b/nbio/nbio_darwin.odin
@@ -10,7 +10,7 @@ import kqueue "_kqueue"
 _init :: proc(io: ^IO, allocator := context.allocator) -> (err: os.Errno) {
 	qerr: kqueue.Queue_Error
 	io.kq, qerr = kqueue.kqueue()
-	if qerr != .None do return kq_err_to_os_err(qerr)
+	if qerr != .None { return kq_err_to_os_err(qerr) }
 
 	pool_init(&io.completion_pool, allocator = allocator)
 

--- a/nbio/nbio_internal_linux.odin
+++ b/nbio/nbio_internal_linux.odin
@@ -110,12 +110,14 @@ Op_Poll_Remove :: struct {
 	event: Poll_Event,
 }
 
-flush :: proc(io: ^IO, wait_nr: u32, timeouts: ^uint, etime: ^bool) -> os.Errno {
-	err := flush_submissions(io, wait_nr, timeouts, etime)
-	if err != os.ERROR_NONE do return err
+flush :: proc(io: ^IO, wait_nr: u32, timeouts: ^uint, etime: ^bool) -> (err: os.Errno) {
+	if err = flush_submissions(io, wait_nr, timeouts, etime); err != os.ERROR_NONE {
+		return err
+	}
 
-	err = flush_completions(io, 0, timeouts, etime)
-	if err != os.ERROR_NONE do return err
+	if err = flush_completions(io, 0, timeouts, etime); err != os.ERROR_NONE {
+		return err
+	}
 
 	// Store length at this time, so we don't infinite loop if any of the enqueue
 	// procs below then add to the queue again.
@@ -169,7 +171,7 @@ flush_completions :: proc(io: ^IO, wait_nr: u32, timeouts: ^uint, etime: ^bool) 
 	wait_remaining := wait_nr
 	for {
 		completed, err := io_uring.copy_cqes(&io.ring, cqes[:], wait_remaining)
-		if err != .None do return ring_err_to_os_err(err)
+		if err != .None { return ring_err_to_os_err(err) }
 
 		wait_remaining = max(0, wait_remaining - completed)
 
@@ -194,7 +196,7 @@ flush_completions :: proc(io: ^IO, wait_nr: u32, timeouts: ^uint, etime: ^bool) 
 			}
 		}
 
-		if completed < len(cqes) do break
+		if completed < len(cqes) { break }
 	}
 
 	return os.ERROR_NONE
@@ -210,7 +212,7 @@ flush_submissions :: proc(io: ^IO, wait_nr: u32, timeouts: ^uint, etime: ^bool) 
 			continue
 		case .Completion_Queue_Overcommitted, .System_Resources:
 			ferr := flush_completions(io, 1, timeouts, etime)
-			if ferr != os.ERROR_NONE do return ferr
+			if ferr != os.ERROR_NONE { return ferr }
 			continue
 		case:
 			return ring_err_to_os_err(err)

--- a/nbio/nbio_linux.odin
+++ b/nbio/nbio_linux.odin
@@ -64,18 +64,20 @@ _tick :: proc(io: ^IO) -> os.Errno {
 
 			sqe, err = io_uring.timeout(&io.ring, 0, &t, 1, 0)
 		}
-		if err != nil do return ring_err_to_os_err(err)
+		if err != nil { return ring_err_to_os_err(err) }
 
 		timeouts += 1
 		io.ios_queued += 1
 
-		ferr := flush(io, 1, &timeouts, &etime)
-		if ferr != os.ERROR_NONE do return ferr
+		if ferr := flush(io, 1, &timeouts, &etime); ferr != os.ERROR_NONE {
+			return ferr
+		}
 	}
 
 	for timeouts > 0 {
-		fcerr := flush_completions(io, 0, &timeouts, &etime)
-		if fcerr != os.ERROR_NONE do return fcerr
+		if fcerr := flush_completions(io, 0, &timeouts, &etime); fcerr != os.ERROR_NONE {
+			return fcerr
+		}
 	}
 
 	return os.ERROR_NONE

--- a/nbio/nbio_unix.odin
+++ b/nbio/nbio_unix.odin
@@ -6,11 +6,13 @@ import "core:net"
 import "core:os"
 
 _open :: proc(_: ^IO, path: string, mode, perm: int) -> (handle: os.Handle, errno: os.Errno) {
-	handle, errno = os.open(path, mode, perm)
-	if errno != os.ERROR_NONE do return
+	if handle, errno = os.open(path, mode, perm); errno != os.ERROR_NONE {
+		return
+	}
 
-	errno = _prepare_handle(handle)
-	if errno != os.ERROR_NONE do os.close(handle)
+	if errno = _prepare_handle(handle); errno != os.ERROR_NONE {
+		os.close(handle)
+	}
 	return
 }
 
@@ -35,11 +37,13 @@ _open_socket :: proc(
 	socket: net.Any_Socket,
 	err: net.Network_Error,
 ) {
-	socket, err = net.create_socket(family, protocol)
-	if err != nil do return
+	if socket, err = net.create_socket(family, protocol); err != nil {
+		return
+	}
 
-	err = _prepare_socket(socket)
-	if err != nil do net.close(socket)
+	if err = _prepare_socket(socket); err != nil {
+		net.close(socket)
+	}
 	return
 }
 

--- a/nbio/nbio_windows.odin
+++ b/nbio/nbio_windows.odin
@@ -219,11 +219,13 @@ _open_socket :: proc(
 	socket: net.Any_Socket,
 	err: net.Network_Error,
 ) {
-	socket, err = net.create_socket(family, protocol)
-	if err != nil do return
+	if socket, err = net.create_socket(family, protocol); err != nil {
+		return
+	}
 
-	err = prepare_socket(io, socket)
-	if err != nil do net.close(socket)
+	if err = prepare_socket(io, socket); err != nil {
+		net.close(socket)
+	}
 	return
 }
 
@@ -295,7 +297,9 @@ _write :: proc(
 
 _recv :: proc(io: ^IO, socket: net.Any_Socket, buf: []byte, user: rawptr, callback: On_Recv, all := false) -> ^Completion {
 	// TODO: implement UDP.
-	if _, ok := socket.(net.UDP_Socket); ok do unimplemented("nbio.recv with UDP sockets is not yet implemented")
+	if _, ok := socket.(net.UDP_Socket); ok {
+		unimplemented("nbio.recv with UDP sockets is not yet implemented")
+	}
 
 	return submit(
 		io,
@@ -320,7 +324,9 @@ _send :: proc(
 	all := false,
 ) -> ^Completion {
 	// TODO: implement UDP.
-	if _, ok := socket.(net.UDP_Socket); ok do unimplemented("nbio.send with UDP sockets is not yet implemented")
+	if _, ok := socket.(net.UDP_Socket); ok {
+		unimplemented("nbio.send with UDP sockets is not yet implemented")
+	}
 
 	return submit(
 		io,

--- a/openssl/openssl.odin
+++ b/openssl/openssl.odin
@@ -46,8 +46,8 @@ VERSION: Version
 
 @(private, init)
 version_check :: proc() {
-    VERSION = Version(OpenSSL_version_num())
-    assert(VERSION.major == 3, "invalid OpenSSL library version, expected 3.x")
+	VERSION = Version(OpenSSL_version_num())
+	assert(VERSION.major == 3, "invalid OpenSSL library version, expected 3.x")
 }
 
 SSL_METHOD :: struct {}

--- a/response.odin
+++ b/response.odin
@@ -69,7 +69,7 @@ body_set :: proc{
 Sets the status code with the safety of being able to do this after writing (part of) the body.
 */
 response_status :: proc(r: ^Response, status: Status) {
-	if r.status == status do return
+	if r.status == status { return }
 
 	r.status = status
 
@@ -122,7 +122,7 @@ response_writer_init :: proc(rw: ^Response_Writer, r: ^Response, buffer: []byte)
 			ws :: bytes.buffer_write_string
 			write_chunk :: proc(b: ^bytes.Buffer, chunk: []byte) {
 				plen := i64(len(chunk))
-				if plen == 0 do return
+				if plen == 0 { return }
 
 				log.debugf("response_writer chunk of size: %i", plen)
 
@@ -214,7 +214,9 @@ You can pass `content_length < 0` to omit the content-length header, note that t
 required on most responses, but there are things like transfer-encodings that could leave it out.
 */
 _response_write_heading :: proc(r: ^Response, content_length: int) {
-	if r._heading_written do return
+	if r._heading_written {
+		return
+	}
 	r._heading_written = true
 
 	ws   :: bytes.buffer_write_string
@@ -327,7 +329,7 @@ response_send_got_body :: proc(r: ^Response, will_close: bool) {
 	conn := r._conn
 
 	if will_close {
-		if !connection_set_state(r._conn, .Will_Close) do return
+		if !connection_set_state(r._conn, .Will_Close) { return }
 	}
 
 	if bytes.buffer_length(&r._buf) == 0 {
@@ -345,7 +347,9 @@ on_response_sent :: proc(conn_: rawptr, sent: int, err: net.Network_Error) {
 
 	if err != nil {
 		log.errorf("could not send response: %v", err)
-		if !connection_set_state(conn, .Will_Close) do return
+		if !connection_set_state(conn, .Will_Close) {
+			return
+		}
 	}
 
 	clean_request_loop(conn)
@@ -366,7 +370,9 @@ clean_request_loop :: proc(conn: ^Connection, close: Maybe(bool) = nil) {
 	if c, ok := close.?; (ok && c) || conn.state == .Will_Close {
 		connection_close(conn)
 	} else {
-		if !connection_set_state(conn, .Idle) do return
+		if !connection_set_state(conn, .Idle) {
+			return
+		}
 		conn_handle_req(conn, context.temp_allocator)
 	}
 }

--- a/routing.odin
+++ b/routing.odin
@@ -48,7 +48,7 @@ Query_Entry :: struct {
 }
 
 query_iter :: proc(query: ^string) -> (entry: Query_Entry, ok: bool) {
-	if len(query) == 0 do return
+	if len(query) == 0 { return }
 
 	ok = true
 

--- a/server.odin
+++ b/server.odin
@@ -166,7 +166,9 @@ serve :: proc(s: ^Server, h: Handler) -> (err: net.Network_Error) {
 	log.debug("server threads are done, shutting down")
 
 	net.close(s.tcp_sock)
-	for t in s.threads do thread.destroy(t)
+	for t in s.threads {
+		thread.destroy(t)
+	}
 	delete(s.threads)
 
 	return nil
@@ -199,16 +201,20 @@ _server_thread_init :: proc(s: ^Server) {
 	log.debug("starting event loop")
 	td.state = .Serving
 	for {
-		if atomic_load(&s.closing) do _server_thread_shutdown(s)
-		if td.state == .Closed do break
-		if td.state == .Cleaning do continue
+		if atomic_load(&s.closing) {
+			_server_thread_shutdown(s)
+		}
+		if td.state == .Closed   { break }
+		if td.state == .Cleaning { continue }
 
 		errno := nbio.tick(&td.io)
 		if errno != os.ERROR_NONE {
 			// TODO: check how this behaves on Windows.
-			when ODIN_OS != .Windows do if errno == os.EINTR {
-				server_shutdown(s)
-				continue
+			when ODIN_OS != .Windows {
+				if errno == os.EINTR {
+					server_shutdown(s)
+					continue
+				}
 			}
 
 			log.errorf("non-blocking io tick error: %v", errno)
@@ -268,7 +274,9 @@ _server_thread_shutdown :: proc(s: ^Server, loc := #caller_location) {
 				connection_close(conn)
 			case .Closing:
 				// Only logging this every 10_000 calls to avoid spam.
-				if i % 10_000 == 0 do log.debugf("shutdown: connection %i is closing", sock)
+				if i % 10_000 == 0 {
+					log.debugf("shutdown: connection %i is closing", sock)
+				}
 			case .Closed:
 				log.warn("closed connection in connections map, maybe a race or logic error")
 			}
@@ -461,7 +469,9 @@ conn_handle_req :: proc(c: ^Connection, allocator := context.temp_allocator) {
 	on_rline1 :: proc(loop: rawptr, token: string, err: bufio.Scanner_Error) {
 		l := cast(^Loop)loop
 
-		if !connection_set_state(l.conn, .Active) do return
+		if !connection_set_state(l.conn, .Active) {
+			return
+		}
 
 		if err != nil {
 			if err == .EOF {

--- a/status.odin
+++ b/status.odin
@@ -118,7 +118,9 @@ status_valid :: proc(s: Status) -> bool {
 }
 
 status_from_string :: proc(s: string) -> (Status, bool) {
-	if len(s) < 3 do return {}, false
+	if len(s) < 3 {
+		return {}, false
+	}
 
 	code_int := int(s[0]-'0')*100 + (int(s[1]-'0')*10) + int(s[2]-'0')
 


### PR DESCRIPTION
Cleaned up to pass `odin check . -vet -vet-tabs -strict-style -vet-style -warnings-as-errors -disallow-do` on Windows, Linux and Darwin.

Also had to update some error handling due to recent `core:net` changes.