### PR TITLE
Allow linking supplied OpenSSL lib on Windows without OPENSSL_SHARED

### DIFF
--- a/openssl/openssl.odin
+++ b/openssl/openssl.odin
@@ -12,7 +12,7 @@ when ODIN_OS == .Windows {
 			"./includes/windows/libcrypto.lib",
 		}
 	} else {
-		@(extra_linker_flags="/nodefaultlib:libcmt")
+		// @(extra_linker_flags="/nodefaultlib:libcmt")
 		foreign import lib {
 			"./includes/windows/libssl_static.lib",
 			"./includes/windows/libcrypto_static.lib",


### PR DESCRIPTION
`odin-http` currently works on Windows if `OPENSSL_SHARED` is true. Removing the extra linker flags allow statically linking as well.

Without it you run into linker errors:
```
LINK : error LNK2001: unresolved external symbol mainCRTStartup
libcrypto_static.lib(libcrypto-lib-siv128.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcrypto-lib-slh_hypertree.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcrypto-lib-ml_dsa_encoders.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcrypto-lib-ml_dsa_sign.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcrypto-lib-slh_dsa.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcrypto-lib-slh_hash.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libdefault-lib-cipher_aes_gcm_siv_hw.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcrypto-lib-cmac.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libdefault-lib-ssl3_cbc.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcrypto-lib-siphash.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcommon-lib-ciphercommon_block.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcommon-lib-ciphercommon_gcm.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libcommon-lib-ciphercommon_ccm.obj) : error LNK2001: unresolved external symbol memcpy
libcrypto_static.lib(libdefault-lib-cipher_tdes_common.obj) : error LNK2001: unresolved external symbol memcpy
<snip>
W:\Odin\shared\http\examples\client\client.exe : fatal error LNK1120: 69 unresolved externals
```