### PR TITLE
Fix `-disallow-do` Errors

### DIFF
--- a/body.odin
+++ b/body.odin
@@ -60,7 +60,7 @@ body_url_encoded :: proc(plain: Body, allocator := context.temp_allocator) -> (r
 
 	count := 1
 	for b in plain {
-		if b == '&' do count += 1
+		if b == '&' { count += 1 }
 	}
 
 	queries := make(map[string]string, count, allocator)

--- a/cookie.odin
+++ b/cookie.odin
@@ -94,7 +94,7 @@ cookie_parse :: proc(value: string, allocator := context.allocator) -> (cookie: 
 	value := value
 
 	eq := strings.index_byte(value, '=')
-	if eq < 1 do return
+	if eq < 1 { return }
 
 	cookie.name = value[:eq]
 	value = value[eq + 1:]
@@ -372,7 +372,7 @@ request_cookie_get :: proc(r: ^Request, key: string) -> (value: string, ok: bool
 	cookies := headers_get_unsafe(r.headers, "cookie") or_return
 
 	for k, v in request_cookies_iter(&cookies) {
-		if key == k do return v, true
+		if key == k { return v, true }
 	}
 
 	return
@@ -389,7 +389,7 @@ request_cookies :: proc(r: ^Request, allocator := context.temp_allocator) -> (re
 	cookies := headers_get_unsafe(r.headers, "cookie") or_else ""
 	for k, v in request_cookies_iter(&cookies) {
 		// Don't overwrite, the iterator goes from right to left and we want the last.
-		if k in res do continue
+		if k in res { continue }
 
 		res[k] = v
 	}

--- a/http.odin
+++ b/http.odin
@@ -35,21 +35,21 @@ requestline_parse :: proc(s: string, allocator := context.temp_allocator) -> (li
 	s := s
 
 	next_space := strings.index_byte(s, ' ')
-	if next_space == -1 do return line, .Not_Enough_Fields
+	if next_space == -1 { return line, .Not_Enough_Fields }
 
 	ok: bool
 	line.method, ok = method_parse(s[:next_space])
-	if !ok do return line, .Method_Not_Implemented
+	if !ok { return line, .Method_Not_Implemented }
 	s = s[next_space + 1:]
 
 	next_space = strings.index_byte(s, ' ')
-	if next_space == -1 do return line, .Not_Enough_Fields
+	if next_space == -1 { return line, .Not_Enough_Fields }
 
 	line.target = strings.clone(s[:next_space], allocator)
 	s = s[len(line.target.(string)) + 1:]
 
 	line.version, ok = version_parse(s)
-	if !ok do return line, .Invalid_Version_Format
+	if !ok { return line, .Invalid_Version_Format }
 
 	return
 }
@@ -131,7 +131,7 @@ Method :: enum {
 _method_strings := [?]string{"GET", "POST", "DELETE", "PATCH", "PUT", "HEAD", "CONNECT", "OPTIONS", "TRACE"}
 
 method_string :: proc(m: Method) -> string #no_bounds_check {
-	if m < .Get || m > .Trace do return ""
+	if m < .Get || m > .Trace { return "" }
 	return _method_strings[m]
 }
 
@@ -273,7 +273,7 @@ date_string :: proc(t: time.Time, allocator := context.allocator) -> string {
 }
 
 date_parse :: proc(value: string) -> (t: time.Time, ok: bool) #no_bounds_check {
-	if len(value) != DATE_LENGTH do return
+	if len(value) != DATE_LENGTH { return }
 
 	// Remove 'Fri, '
 	value := value
@@ -294,7 +294,7 @@ date_parse :: proc(value: string) -> (t: time.Time, ok: bool) #no_bounds_check {
 		}
 	}
 	month_index += 1
-	if month_index <= 0 do return
+	if month_index <= 0 { return }
 
 	year := strconv.parse_i64_of_base(value[:4], 10) or_return
 	value = value[4:]
@@ -309,7 +309,7 @@ date_parse :: proc(value: string) -> (t: time.Time, ok: bool) #no_bounds_check {
 	value = value[3:]
 
 	// Should have only 'GMT' left now.
-	if value != "GMT" do return
+	if value != "GMT" { return }
 
 	t = time.datetime_to_time(int(year), int(month_index), int(day), int(hour), int(minute), int(seconds)) or_return
 	ok = true
@@ -437,4 +437,3 @@ test_dynamic_unwritten :: proc(t: ^testing.T) {
 		testing.expect(t, len(du) == 0)
 	}
 }
-

--- a/nbio/nbio_internal_windows.odin
+++ b/nbio/nbio_internal_windows.odin
@@ -110,7 +110,7 @@ flush_timeouts :: proc(io: ^IO) -> (expires: Maybe(time.Duration)) {
 	timeout_len := len(io.timeouts)
 
 	// PERF: could use a faster clock, is getting time since program start fast?
-	if timeout_len > 0 do curr = time.now()
+	if timeout_len > 0 { curr = time.now() }
 
 	for i := 0; i < timeout_len; {
 		completion := io.timeouts[i]
@@ -174,7 +174,7 @@ handle_completion :: proc(io: ^IO, completion: ^Completion) {
 			return
 		}
 
-		if err != nil do win.closesocket(op.client)
+		if err != nil { win.closesocket(op.client) }
 
 		op.callback(completion.user_data, net.TCP_Socket(op.client), source, err)
 
@@ -185,7 +185,7 @@ handle_completion :: proc(io: ^IO, completion: ^Completion) {
 			return
 		}
 
-		if err != nil do win.closesocket(op.socket)
+		if err != nil { win.closesocket(op.socket) }
 
 		op.callback(completion.user_data, net.TCP_Socket(op.socket), err)
 
@@ -320,7 +320,7 @@ accept_callback :: proc(io: ^IO, comp: ^Completion, op: ^Op_Accept) -> (source: 
 		oclient: net.Any_Socket
 		oclient, err = open_socket(io, .IP4, .TCP)
 
-		if err != nil do return
+		if err != nil { return }
 
 		op.client = win.SOCKET(net.any_socket_to_socket(oclient))
 
@@ -365,20 +365,20 @@ connect_callback :: proc(io: ^IO, comp: ^Completion, op: ^Op_Connect) -> (err: n
 		osocket: net.Any_Socket
 		osocket, err = open_socket(io, .IP4, .TCP)
 
-		if err != nil do return
+		if err != nil { return }
 
 		op.socket = win.SOCKET(net.any_socket_to_socket(osocket))
 
 		sockaddr := endpoint_to_sockaddr({net.IP4_Any, 0})
 		res := win.bind(op.socket, &sockaddr, size_of(sockaddr))
-		if res < 0 do return net._bind_error()
+		if res < 0 { return net._bind_error() }
 
 		connect_ex: LPFN_CONNECTEX
 		load_socket_fn(op.socket, WSAID_CONNECTEX, &connect_ex)
 		// TODO: size_of(win.sockaddr_in6) when ip6.
 		ok = connect_ex(op.socket, &op.addr, size_of(win.sockaddr_in) + 16, nil, 0, &transferred, &comp.over)
 	}
-	if !ok do return net._dial_error()
+	if !ok { return net._dial_error() }
 
 	// enables getsockopt, setsockopt, getsockname, getpeername.
 	win.setsockopt(op.socket, win.SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT, nil, 0)
@@ -416,12 +416,12 @@ read_callback :: proc(io: ^IO, comp: ^Completion, op: ^Op_Read) -> (read: win.DW
 		ok = win.ReadFile(win.HANDLE(op.fd), raw_data(op.buf), win.DWORD(len(op.buf)), &read, &comp.over)
 
 		// Not sure if this also happens with correctly set up handles some times.
-		if ok do log.info("non-blocking read returned immediately, is the handle set up correctly?")
+		if ok { log.info("non-blocking read returned immediately, is the handle set up correctly?") }
 
 		op.pending = true
 	}
 
-	if !ok do err = win.GetLastError()
+	if !ok { err = win.GetLastError() }
 
 	// Increment offset if this was not a call with an offset set.
 	if op.offset >= 0 {
@@ -441,12 +441,12 @@ write_callback :: proc(io: ^IO, comp: ^Completion, op: ^Op_Write) -> (written: w
 		ok = win.WriteFile(win.HANDLE(op.fd), raw_data(op.buf), win.DWORD(len(op.buf)), &written, &comp.over)
 
 		// Not sure if this also happens with correctly set up handles some times.
-		if ok do log.debug("non-blocking write returned immediately, is the handle set up correctly?")
+		if ok { log.debug("non-blocking write returned immediately, is the handle set up correctly?") }
 
 		op.pending = true
 	}
 
-	if !ok do err = win.GetLastError()
+	if !ok { err = win.GetLastError() }
 
 	// Increment offset if this was not a call with an offset set.
 	if op.offset >= 0 {
@@ -469,7 +469,7 @@ recv_callback :: proc(io: ^IO, comp: ^Completion, op: ^Op_Recv) -> (received: wi
 		op.pending = true
 	}
 
-	if !ok do err = net._tcp_recv_error()
+	if !ok { err = net._tcp_recv_error() }
 	return
 }
 
@@ -485,7 +485,7 @@ send_callback :: proc(io: ^IO, comp: ^Completion, op: ^Op_Send) -> (sent: win.DW
 		op.pending = true
 	}
 
-	if !ok do err = net._tcp_send_error()
+	if !ok { err = net._tcp_send_error() }
 	return
 }
 

--- a/nbio/nbio_windows.odin
+++ b/nbio/nbio_windows.odin
@@ -220,10 +220,10 @@ _open_socket :: proc(
 	err: net.Network_Error,
 ) {
 	socket, err = net.create_socket(family, protocol)
-	if err != nil do return
+	if err != nil { return }
 
 	err = prepare_socket(io, socket)
-	if err != nil do net.close(socket)
+	if err != nil { net.close(socket) }
 	return
 }
 
@@ -295,7 +295,7 @@ _write :: proc(
 
 _recv :: proc(io: ^IO, socket: net.Any_Socket, buf: []byte, user: rawptr, callback: On_Recv, all := false) -> ^Completion {
 	// TODO: implement UDP.
-	if _, ok := socket.(net.UDP_Socket); ok do unimplemented("nbio.recv with UDP sockets is not yet implemented")
+	if _, ok := socket.(net.UDP_Socket); ok { unimplemented("nbio.recv with UDP sockets is not yet implemented") }
 
 	return submit(
 		io,
@@ -320,7 +320,7 @@ _send :: proc(
 	all := false,
 ) -> ^Completion {
 	// TODO: implement UDP.
-	if _, ok := socket.(net.UDP_Socket); ok do unimplemented("nbio.send with UDP sockets is not yet implemented")
+	if _, ok := socket.(net.UDP_Socket); ok { unimplemented("nbio.send with UDP sockets is not yet implemented") }
 
 	return submit(
 		io,

--- a/response.odin
+++ b/response.odin
@@ -69,7 +69,7 @@ body_set :: proc{
 Sets the status code with the safety of being able to do this after writing (part of) the body.
 */
 response_status :: proc(r: ^Response, status: Status) {
-	if r.status == status do return
+	if r.status == status { return }
 
 	r.status = status
 
@@ -122,7 +122,7 @@ response_writer_init :: proc(rw: ^Response_Writer, r: ^Response, buffer: []byte)
 			ws :: bytes.buffer_write_string
 			write_chunk :: proc(b: ^bytes.Buffer, chunk: []byte) {
 				plen := i64(len(chunk))
-				if plen == 0 do return
+				if plen == 0 { return }
 
 				log.debugf("response_writer chunk of size: %i", plen)
 
@@ -214,7 +214,7 @@ You can pass `content_length < 0` to omit the content-length header, note that t
 required on most responses, but there are things like transfer-encodings that could leave it out.
 */
 _response_write_heading :: proc(r: ^Response, content_length: int) {
-	if r._heading_written do return
+	if r._heading_written { return }
 	r._heading_written = true
 
 	ws   :: bytes.buffer_write_string
@@ -327,7 +327,7 @@ response_send_got_body :: proc(r: ^Response, will_close: bool) {
 	conn := r._conn
 
 	if will_close {
-		if !connection_set_state(r._conn, .Will_Close) do return
+		if !connection_set_state(r._conn, .Will_Close) { return }
 	}
 
 	if bytes.buffer_length(&r._buf) == 0 {
@@ -345,7 +345,7 @@ on_response_sent :: proc(conn_: rawptr, sent: int, err: net.Network_Error) {
 
 	if err != nil {
 		log.errorf("could not send response: %v", err)
-		if !connection_set_state(conn, .Will_Close) do return
+		if !connection_set_state(conn, .Will_Close) { return }
 	}
 
 	clean_request_loop(conn)
@@ -366,7 +366,7 @@ clean_request_loop :: proc(conn: ^Connection, close: Maybe(bool) = nil) {
 	if c, ok := close.?; (ok && c) || conn.state == .Will_Close {
 		connection_close(conn)
 	} else {
-		if !connection_set_state(conn, .Idle) do return
+		if !connection_set_state(conn, .Idle) { return }
 		conn_handle_req(conn, context.temp_allocator)
 	}
 }

--- a/routing.odin
+++ b/routing.odin
@@ -48,7 +48,7 @@ Query_Entry :: struct {
 }
 
 query_iter :: proc(query: ^string) -> (entry: Query_Entry, ok: bool) {
-	if len(query) == 0 do return
+	if len(query) == 0 { return }
 
 	ok = true
 

--- a/server.odin
+++ b/server.odin
@@ -166,7 +166,7 @@ serve :: proc(s: ^Server, h: Handler) -> (err: net.Network_Error) {
 	log.debug("server threads are done, shutting down")
 
 	net.close(s.tcp_sock)
-	for t in s.threads do thread.destroy(t)
+	for t in s.threads { thread.destroy(t) }
 	delete(s.threads)
 
 	return nil
@@ -199,16 +199,18 @@ _server_thread_init :: proc(s: ^Server) {
 	log.debug("starting event loop")
 	td.state = .Serving
 	for {
-		if atomic_load(&s.closing) do _server_thread_shutdown(s)
-		if td.state == .Closed do break
-		if td.state == .Cleaning do continue
+		if atomic_load(&s.closing) { _server_thread_shutdown(s) }
+		if td.state == .Closed { break }
+		if td.state == .Cleaning { continue }
 
 		errno := nbio.tick(&td.io)
 		if errno != os.ERROR_NONE {
 			// TODO: check how this behaves on Windows.
-			when ODIN_OS != .Windows do if errno == os.EINTR {
-				server_shutdown(s)
-				continue
+			when ODIN_OS != .Windows {
+				if errno == os.EINTR {
+					server_shutdown(s)
+					continue
+				}
 			}
 
 			log.errorf("non-blocking io tick error: %v", errno)
@@ -268,7 +270,7 @@ _server_thread_shutdown :: proc(s: ^Server, loc := #caller_location) {
 				connection_close(conn)
 			case .Closing:
 				// Only logging this every 10_000 calls to avoid spam.
-				if i % 10_000 == 0 do log.debugf("shutdown: connection %i is closing", sock)
+				if i % 10_000 == 0 { log.debugf("shutdown: connection %i is closing", sock) }
 			case .Closed:
 				log.warn("closed connection in connections map, maybe a race or logic error")
 			}
@@ -461,7 +463,7 @@ conn_handle_req :: proc(c: ^Connection, allocator := context.temp_allocator) {
 	on_rline1 :: proc(loop: rawptr, token: string, err: bufio.Scanner_Error) {
 		l := cast(^Loop)loop
 
-		if !connection_set_state(l.conn, .Active) do return
+		if !connection_set_state(l.conn, .Active) { return }
 
 		if err != nil {
 			if err == .EOF {

--- a/status.odin
+++ b/status.odin
@@ -118,7 +118,7 @@ status_valid :: proc(s: Status) -> bool {
 }
 
 status_from_string :: proc(s: string) -> (Status, bool) {
-	if len(s) < 3 do return {}, false
+	if len(s) < 3 { return {}, false }
 
 	code_int := int(s[0]-'0')*100 + (int(s[1]-'0')*10) + int(s[2]-'0')
 


### PR DESCRIPTION
This ensures everyone (regardless of compiler flags) are able to use the library.