### PR TITLE
fix client cookies delete allocator

### DIFF
--- a/client/client.odin
+++ b/client/client.odin
@@ -160,7 +160,7 @@ response_destroy :: proc(res: ^Response, body: Maybe(Body_Type) = nil, was_alloc
 	bufio.scanner_destroy(&res._body)
 
 	for cookie in res.cookies {
-		delete(cookie._raw)
+		delete(cookie._raw, res.cookies.allocator)
 	}
 	delete(res.cookies)
 


### PR DESCRIPTION
response_destroy was calling delete(cookie._raw) without specifying an allocator, causing it to fall back to context.allocator instead of the allocator used when the response was allocated. This results in an access violation when the response was allocated with a different allocator (e.g. context.temp_allocator).

Fix by passing res.cookies.allocator explicitly to delete(cookie._raw).

Fixes #109 