### PR TITLE
client: fix scanner buffer leak in parse_response; expose dial()/request_on()

### DIFF
--- a/client/client.odin
+++ b/client/client.odin
@@ -81,16 +81,24 @@ Error :: union #shared_nil {
 	SSL_Error,
 }
 
-request :: proc(request: ^Request, target: string, allocator := context.allocator) -> (res: Response, err: Error) {
-	url, endpoint := parse_endpoint(target) or_return
+dial :: proc(target: string) -> (socket: net.TCP_Socket, url: http.URL, err: Error) {
+	endpoint: net.Endpoint
+	url, endpoint = parse_endpoint(target) or_return
+	socket = net.dial_tcp(endpoint) or_return
+	return
+}
 
+request_on :: proc(
+	request: ^Request,
+	socket: net.TCP_Socket,
+	url: http.URL,
+	allocator := context.allocator,
+) -> (res: Response, err: Error) {
 	// NOTE: we don't support persistent connections yet.
 	http.headers_set_close(&request.headers)
 
 	req_buf := format_request(url, request, allocator)
 	defer bytes.buffer_destroy(&req_buf)
-
-	socket := net.dial_tcp(endpoint) or_return
 
 	// HTTPS using openssl.
 	if url.scheme == "https" {
@@ -131,6 +139,15 @@ request :: proc(request: ^Request, target: string, allocator := context.allocato
 	// HTTP, just send the request.
 	net.send_tcp(socket, bytes.buffer_to_bytes(&req_buf)) or_return
 	return parse_response(socket, allocator)
+}
+
+request :: proc(request: ^Request, target: string, allocator := context.allocator) -> (res: Response, err: Error) {
+	socket, url := dial(target) or_return
+	res, err = request_on(request, socket, url, allocator)
+	if err != nil {
+		net.close(socket)
+	}
+	return
 }
 
 Response :: struct {

--- a/client/communication.odin
+++ b/client/communication.odin
@@ -139,6 +139,7 @@ parse_response :: proc(socket: Communication, allocator := context.allocator) ->
 	stream_reader := io.to_reader(stream)
 	scanner: bufio.Scanner
 	bufio.scanner_init(&scanner, stream_reader, allocator)
+	defer if err != nil { bufio.scanner_destroy(&scanner) }
 
 	http.headers_init(&res.headers, allocator)
 


### PR DESCRIPTION
Two small, independent client-side fixes. Happy to split into separate PRs if you'd prefer — both files are easy to land in either order.

## 1. Free the scanner buffer on every `parse_response` error return

`parse_response` initialises a `bufio.Scanner` whose 4 KiB backing buffer is allocated lazily on the first `scanner_scan` call (\`core/bufio/scanner.odin:184\`). The happy path hands the scanner to \`res._body\` at line 212, where \`response_destroy → scanner_destroy\` frees it. Every error-return path between the first scan and the handoff abandons the buffer.

A guarded \`defer if err != nil { bufio.scanner_destroy(&scanner) }\` right after \`scanner_init\` plugs all of them:

- Connection EOFs before the status line — `scanner_error` at lines 145-147
- Malformed HTTP version — `Invalid_Response_HTTP_Version` at lines 154-157, 160-163
- Malformed status line — `Invalid_Response_Method` at lines 165-169
- Header scan failure — `scanner_error` at lines 174-177
- Malformed header line — `Invalid_Response_Header` at lines 183-187
- Malformed Set-Cookie — `Invalid_Response_Cookie` at lines 194-199
- `headers_validate` fails — `Invalid_Response_Header` at lines 205-208

`scanner_destroy` is a no-op on a never-allocated buffer (delete on a nil slice), so the guard is safe even on paths that fail before the first scan.

**Reproduction:** [http-leak](https://github.com/sstoehrm/redin/issues/156) — minimal Odin program pinned at \`3b46a46\` that opens a loopback peer which closes immediately. Tracking allocator reports the 4 KiB leak before this PR, clean after.

## 2. Expose `dial()` and `request_on()`

\`client.request()\` was monolithic: dial + (optional SSL setup) + send + parse, never exposing the underlying socket. Callers running a request on a worker thread therefore have no way to interrupt \`parse_response\`'s blocking \`net.recv_tcp\` from outside — the worker can park indefinitely on a slow remote, blocking graceful shutdown.

This PR splits the connection step out:

\`\`\`odin
dial       :: proc(target: string)
              -> (socket: net.TCP_Socket, url: http.URL, err: Error)
request_on :: proc(req, socket, url, allocator)
              -> (res: Response, err: Error)
request    :: proc(req, target, allocator)
              -> (res: Response, err: Error)   // now a thin wrapper
\`\`\`

\`request()\` is kept as a convenience wrapper around \`dial\` + \`request_on\` so \`get()\` and every existing call site compile unchanged. As a small bonus it now closes the socket on error, fixing a pre-existing leak when the SSL handshake fails (the old code would early-return from inside the \`https\` branch without closing).

**Why this shape?** It lets a downstream stash the freshly-dialed fd in a per-request registry and \`net.close\` it from another thread to unblock a stuck \`recv_tcp\` (\`Connection_Closed\` propagates as \`Unexpected_EOF\` through \`_socket_stream_proc\`, the scanner errors, and combined with PR change #1 the buffer is freed). The alternative I tried first was a \`socket_hook: proc(socket, user: rawptr) = nil\` callback on \`request\`, but the split is cleaner: no callback, no userdata rawptr, and \`request_on\` is independently useful for anyone who wants to dial once and retry (think connection pools).

**Ownership semantics:** \`dial\` returns the socket to the caller. \`request_on\` succeeds → \`Response._socket\` owns it → \`response_destroy\` closes. \`request_on\` errors → caller still owns the socket and must close. \`request()\` (the wrapper) handles both cases for the common case where the caller doesn't care.

## Test plan

- Builds the existing \`examples/client\` unchanged.
- Downstream consumer (a UI framework with an HTTP-effect runtime) exercises both halves: 57 bridge tests pass under the Odin tracking allocator with zero unfreed allocations, where previously stuck-worker shutdown leaked up to 256 KiB across 64 in-flight requests.

Repo: [sstoehrm/redin#159](https://github.com/sstoehrm/redin/pull/159) (the downstream wiring).